### PR TITLE
feature: Toggleable case sensitivity.

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -8,17 +8,37 @@ const sortLine = require('./sort/line')
 const sortLines = require('./sort/lines')
 const sortYAML = require('./sort/yaml')
 
+// region config
+
+const config = {
+	caseSensitive: {
+		default: true,
+		description: "When sorting naturally, `['a', 'B']` yields `['B', 'a']` rather than `['a', 'B']`.",
+		title: 'Case Sensitive Natural Sort',
+		type: 'boolean',
+	}
+}
+
+// endregion
+
 // region subscriptions
 
 const subscriptions = new CompositeDisposable()
 
-const activate = () =>
+const activate = () => {
+	natural.insensitive = !atom.config.get('sorter.caseSensitive')
+
+	subscriptions.add(
+		atom.config.onDidChange('sorter.caseSensitive', ({ newValue }) => natural.insensitive = !newValue)
+	)
+
 	subscriptions.add(
 		atom.commands.add('atom-workspace', {
 			'sorter:sort': () => sort(),
 			'sorter:natural-sort': () => sort(natural),
 		})
 	)
+}
 
 const deactivate = () => subscriptions.dispose()
 
@@ -52,4 +72,4 @@ const sort = sortingFunction => {
 
 // endregion
 
-module.exports = { activate, deactivate }
+module.exports = { activate, config, deactivate }


### PR DESCRIPTION
👋 Hiya! This is a quick PR for your lovely package that allows the user to toggle `javascript-natural-sort`'s case sensitivity on or off. It's set to case-sensitive by default, so users who don't care won't notice any difference; but flipping the flag will update the natural sort's behavior.

Thanks for your work on this package! It's my favorite sorty-dealie yet.

#### Contrived Demo
![screenflow](https://user-images.githubusercontent.com/2207980/52190119-185cd880-280b-11e9-9ab1-10ae7bf9ea4a.gif)
